### PR TITLE
feat: adding prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "mocha": "^2.2.5",
     "opener": "^1.4.1",
     "phantomjs": "^1.9.18",
+    "prop-types": "^15.6.2",
     "react": "^0.14.0",
     "react-docgen": "^2.2.0",
     "react-dom": "^0.14.0",

--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from "react";
 
 const makeArray = (obj) =>
@@ -82,5 +83,5 @@ export default class API extends React.Component {
 }
 
 API.propTypes = {
-  source: React.PropTypes.object
+  source: PropTypes.object
 };

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from "react";
 import API from "./api";
 import Overview from "./overview";
@@ -29,9 +30,9 @@ export default class Ecology extends React.Component {
 }
 
 Ecology.propTypes = {
-  collapsableCode: React.PropTypes.bool,
-  overview: React.PropTypes.string,
-  playgroundtheme: React.PropTypes.string,
-  source: React.PropTypes.object,
-  scope: React.PropTypes.object
+  collapsableCode: PropTypes.bool,
+  overview: PropTypes.string,
+  playgroundtheme: PropTypes.string,
+  source: PropTypes.object,
+  scope: PropTypes.object
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from "react";
 import ReactDOM from "react-dom";
 import marked from "marked";
@@ -59,8 +60,8 @@ class Overview extends React.Component {
 export default Overview;
 
 Overview.propTypes = {
-  collapsableCode: React.PropTypes.bool,
-  markdown: React.PropTypes.string,
-  playgroundtheme: React.PropTypes.string,
-  scope: React.PropTypes.object
+  collapsableCode: PropTypes.bool,
+  markdown: PropTypes.string,
+  playgroundtheme: PropTypes.string,
+  scope: PropTypes.object
 };


### PR DESCRIPTION
Updating the prop-types module so that this doesn't throw error if any project using react 16.